### PR TITLE
Change ARGS.PLEASE_GIVE to have better grammar

### DIFF
--- a/src/languages/en-US/bot.json
+++ b/src/languages/en-US/bot.json
@@ -124,7 +124,7 @@
 	},
 	"ARGS": {
 		"INVALID": "That is not a valid {{type}}!",
-		"PLEASE_GIVE": "Please supply a {{type}}.",
+		"PLEASE_GIVE": "Please supply a(n) {{type}}.",
 		"PLEASE_GIVE_VALID": "That is not a valid {{type}}."
 	},
 	"COMMANDS": {


### PR DESCRIPTION
We would ideally want to only have an or a depending on if {{type}} starts with a vowel or whatever but I'm not too sure the logic extent in the language library